### PR TITLE
fix(auth): correctly identify posthog users via backend on load

### DIFF
--- a/src/components/PostHogPageView.tsx
+++ b/src/components/PostHogPageView.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { usePostHog } from 'posthog-js/react';
+import { api, isAuthenticated } from '../lib/api';
 
 /**
  * Listens to React Router route changes and fires a PostHog $pageview event
@@ -16,6 +17,30 @@ export default function PostHogPageView() {
       $current_url: window.location.href,
     });
   }, [location, posthog]);
+
+  // Identify user on load and on auth-change
+  useEffect(() => {
+    const identifyUser = async () => {
+      if (isAuthenticated()) {
+        try {
+          const profile = await api.getMe();
+          posthog?.identify(profile.id, {
+            email: profile.email,
+            name: profile.full_name,
+          });
+        } catch (err) {
+          console.error("Failed to identify user with backend", err);
+        }
+      }
+    };
+
+    // Run on initial load if returning user
+    identifyUser();
+
+    // Run whenever the token is set or cleared
+    window.addEventListener('auth-change', identifyUser);
+    return () => window.removeEventListener('auth-change', identifyUser);
+  }, [posthog]);
 
   return null;
 }

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -33,14 +33,6 @@ export default function AuthPage() {
       Promise.resolve().then(() => setStatus('processing'));
       setToken(accessToken);
       window.history.replaceState({}, '', '/auth');
-      // Identify the user in PostHog using their JWT sub claim as the ID.
-      // The token is a JWT; we decode the payload to get the user ID.
-      try {
-        const payload = JSON.parse(atob(accessToken.split('.')[1]));
-        posthog?.identify(payload.sub, { email: payload.email });
-      } catch {
-        // Not a JWT or malformed — skip identification silently
-      }
       navigate('/mode', { replace: true });
       return;
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes `posthog-js` user identification by fetching the user profile from the backend and identifying on app load and auth changes. Removes fragile JWT-based identification to ensure consistent IDs and correct attribution.

- **Bug Fixes**
  - Identify via `api.getMe()` when `isAuthenticated()`, using `profile.id`, `email`, and `full_name`.
  - Trigger identification on initial load and on `auth-change` events.
  - Remove JWT decoding from `AuthPage` and centralize identification in `PostHogPageView`.

<sup>Written for commit 621d0c9efb6098451c71a24dd7be6f88675bba76. Summary will update on new commits. <a href="https://cubic.dev/pr/jpdevhub/FreshScanAi/pull/40?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

