### PR TITLE
feat: implement global dark/light mode toggle (#48)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "posthog-js": "^1.376.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-hot-toast": "^2.6.0",
         "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.14.0",
         "tailwindcss": "^4.2.2"
@@ -2170,7 +2171,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2630,6 +2630,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/graceful-fs": {
@@ -3450,6 +3459,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-leaflet": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -279,12 +278,36 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -573,7 +596,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1371,6 +1393,64 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -1473,7 +1553,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1540,7 +1619,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1823,7 +1901,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1942,7 +2019,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2156,8 +2232,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2258,7 +2333,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2828,8 +2902,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3312,7 +3385,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3434,7 +3506,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3444,7 +3515,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3794,7 +3864,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3879,7 +3948,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4067,7 +4135,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -276,27 +277,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -593,6 +573,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1492,6 +1473,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1558,6 +1540,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1840,6 +1823,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1958,6 +1942,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2171,7 +2156,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2272,6 +2258,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2841,7 +2828,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3324,6 +3312,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3445,6 +3434,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3454,6 +3444,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3803,6 +3794,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3887,6 +3879,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4074,6 +4067,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "framer-motion": "^12.38.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "setup": "sh scripts/dev-setup.sh",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "posthog-js": "^1.376.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-hot-toast": "^2.6.0",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.14.0",
     "tailwindcss": "^4.2.2"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import AnalysisDashboard from './pages/AnalysisDashboard';
 import MarketMapPage from './pages/MarketMapPage';
 import ResultsPage from './pages/ResultsPage';
 import PostHogPageView from './components/PostHogPageView';
-import NotFound from './pages/NotFound'; // Importing the new 404 component
+import NotFound from './pages/NotFound';
 
 export default function App() {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Toaster } from 'react-hot-toast';
 import Layout from './components/Layout';
 import LandingPage from './pages/LandingPage';
 import AuthPage from './pages/AuthPage';
@@ -8,12 +9,17 @@ import AnalysisDashboard from './pages/AnalysisDashboard';
 import MarketMapPage from './pages/MarketMapPage';
 import ResultsPage from './pages/ResultsPage';
 import PostHogPageView from './components/PostHogPageView';
+import NotFound from './pages/NotFound'; // Importing the new 404 component
 
 export default function App() {
   return (
     <BrowserRouter>
+      {/* Toast provider for global error notifications */}
+      <Toaster position="bottom-right" />
+      
       {/* Fires a $pageview event to PostHog on every SPA route change */}
       <PostHogPageView />
+      
       <Routes>
         <Route element={<Layout />}>
           <Route path="/" element={<LandingPage />} />
@@ -23,6 +29,9 @@ export default function App() {
           <Route path="/analysis" element={<AnalysisDashboard />} />
           <Route path="/map" element={<MarketMapPage />} />
           <Route path="/results" element={<ResultsPage />} />
+          
+          {/* Catch-all route for broken links/404s */}
+          <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,7 +2,6 @@ import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import BottomNav from './BottomNav';
 import Footer from './Footer';
-import { toggleTheme } from '../lib/theme';
 
 export default function Layout() {
   return (

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom';
 import Navbar from './Navbar';
 import BottomNav from './BottomNav';
 import Footer from './Footer';
+import { toggleTheme } from '../lib/theme';
 
 export default function Layout() {
   return (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from 'react';
 import { usePostHog } from 'posthog-js/react';
 import { api, clearToken, isAuthenticated } from '../lib/api';
 import type { UserProfile } from '../lib/types';
+import { toggleTheme } from '../lib/theme'; // Import the toggle function
 
 export default function Navbar() {
   const location = useLocation();
@@ -45,7 +46,6 @@ export default function Navbar() {
   const handleLogout = () => {
     setIsDropdownOpen(false);
     clearToken();
-    // Reset PostHog session so next user on this device isn't tracked as this user
     posthog?.reset();
     navigate('/');
     setShowToast(true);
@@ -90,51 +90,61 @@ export default function Navbar() {
           ))}
         </div>
 
-        {/* Auth Button & Modal */}
-        {loggedIn ? (
-          <div className="relative" ref={dropdownRef}>
-            <button
-              onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-              className="flex items-center gap-3 bg-surface-low border border-outline-variant/30 text-on-surface px-3 py-1.5 transition-all duration-200 hover:bg-surface-mid ghost-border"
-            >
-              {profile?.avatar_url ? (
-                <img src={profile.avatar_url} referrerPolicy="no-referrer" alt="Profile" className="w-7 h-7 rounded-full object-cover grayscale-[0.5] contrast-125 border border-neon/30" />
-              ) : (
-                <div className="w-7 h-7 bg-surface-highest flex items-center justify-center text-neon text-xs font-bold font-[family-name:var(--font-display)]">
-                  {profile?.full_name?.charAt(0) || 'U'}
+        {/* Auth Button & Theme Toggle */}
+        <div className="flex items-center gap-4">
+          {/* Theme Toggle Button */}
+          <button
+            onClick={toggleTheme}
+            className="font-[family-name:var(--font-mono)] text-[10px] tracking-widest text-on-surface-variant hover:text-neon transition-colors duration-200 border border-outline-variant/30 px-3 py-1"
+          >
+            THEME
+          </button>
+
+          {loggedIn ? (
+            <div className="relative" ref={dropdownRef}>
+              <button
+                onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                className="flex items-center gap-3 bg-surface-low border border-outline-variant/30 text-on-surface px-3 py-1.5 transition-all duration-200 hover:bg-surface-mid ghost-border"
+              >
+                {profile?.avatar_url ? (
+                  <img src={profile.avatar_url} referrerPolicy="no-referrer" alt="Profile" className="w-7 h-7 object-cover grayscale-[0.5] contrast-125 border border-neon/30" />
+                ) : (
+                  <div className="w-7 h-7 bg-surface-highest flex items-center justify-center text-neon text-xs font-bold font-[family-name:var(--font-display)]">
+                    {profile?.full_name?.charAt(0) || 'U'}
+                  </div>
+                )}
+                <span className="text-sm font-[family-name:var(--font-mono)] tracking-wider mr-1 uppercase">
+                  {profile?.full_name ? profile.full_name.split(' ')[0] : 'SESSION'}
+                </span>
+              </button>
+
+              {isDropdownOpen && (
+                <div className="absolute right-0 top-full mt-2 w-48 bg-surface-low border border-outline-variant/30 shadow-2xl p-2 flex flex-col gap-1 z-50">
+                  <Link
+                    to="/results"
+                    onClick={() => setIsDropdownOpen(false)}
+                    className="px-4 py-3 text-sm font-[family-name:var(--font-display)] font-bold text-on-surface-variant hover:text-neon hover:bg-surface-high no-underline transition-colors duration-200 block"
+                  >
+                    RESULTS
+                  </Link>
+                  <button
+                    onClick={handleLogout}
+                    className="px-4 py-3 text-sm font-[family-name:var(--font-display)] font-bold text-error text-left hover:bg-error/10 transition-colors duration-200 block w-full"
+                  >
+                    TERMINATE_SESSION (LOGOUT)
+                  </button>
                 </div>
               )}
-              <span className="text-sm font-[family-name:var(--font-mono)] tracking-wider mr-1 uppercase">
-                {profile?.full_name ? profile.full_name.split(' ')[0] : 'SESSION'}
-              </span>
-            </button>
-
-            {isDropdownOpen && (
-              <div className="absolute right-0 top-full mt-2 w-48 bg-surface-low border border-outline-variant/30 shadow-2xl p-2 flex flex-col gap-1 z-50">
-                <Link
-                  to="/results"
-                  onClick={() => setIsDropdownOpen(false)}
-                  className="px-4 py-3 text-sm font-[family-name:var(--font-display)] font-bold text-on-surface-variant hover:text-neon hover:bg-surface-high no-underline transition-colors duration-200 block"
-                >
-                  RESULTS
-                </Link>
-                <button
-                  onClick={handleLogout}
-                  className="px-4 py-3 text-sm font-[family-name:var(--font-display)] font-bold text-error text-left hover:bg-error/10 transition-colors duration-200 block w-full"
-                >
-                  TERMINATE_SESSION (LOGOUT)
-                </button>
-              </div>
-            )}
-          </div>
-        ) : (
-          <Link
-            to="/auth"
-            className="flex items-center gap-2 bg-neon text-on-primary px-3 py-1.5 md:px-5 md:py-2.5 font-[family-name:var(--font-display)] font-bold text-xs md:text-sm tracking-wide no-underline transition-all duration-200 hover:bg-neon-dim"
-          >
-            SIGN_IN / SIGN_UP
-          </Link>
-        )}
+            </div>
+          ) : (
+            <Link
+              to="/auth"
+              className="flex items-center gap-2 bg-neon text-on-primary px-3 py-1.5 md:px-5 md:py-2.5 font-[family-name:var(--font-display)] font-bold text-xs md:text-sm tracking-wide no-underline transition-all duration-200 hover:bg-neon-dim"
+            >
+              SIGN_IN / SIGN_UP
+            </Link>
+          )}
+        </div>
       </div>
 
       {/* Logout Toast Notification */}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -94,12 +94,12 @@ export default function Navbar() {
         <div className="flex items-center gap-4">
           {/* Theme Toggle Button */}
           <button
+            type="button"
             onClick={toggleTheme}
             className="font-[family-name:var(--font-mono)] text-[10px] tracking-widest text-on-surface-variant hover:text-neon transition-colors duration-200 border border-outline-variant/30 px-3 py-1"
           >
             THEME
           </button>
-
           {loggedIn ? (
             <div className="relative" ref={dropdownRef}>
               <button

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -91,12 +91,12 @@ export default function Navbar() {
         </div>
 
         {/* Auth Button & Theme Toggle */}
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2 sm:gap-4">
           {/* Theme Toggle Button */}
           <button
             type="button"
             onClick={toggleTheme}
-            className="font-[family-name:var(--font-mono)] text-[10px] tracking-widest text-on-surface-variant hover:text-neon transition-colors duration-200 border border-outline-variant/30 px-3 py-1"
+            className="font-[family-name:var(--font-mono)] text-[9px] sm:text-[10px] tracking-widest text-on-surface-variant hover:text-neon transition-colors duration-200 border border-outline-variant/30 px-2 py-1 sm:px-3"
           >
             THEME
           </button>
@@ -104,7 +104,7 @@ export default function Navbar() {
             <div className="relative" ref={dropdownRef}>
               <button
                 onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-                className="flex items-center gap-3 bg-surface-low border border-outline-variant/30 text-on-surface px-3 py-1.5 transition-all duration-200 hover:bg-surface-mid ghost-border"
+                className="flex items-center gap-2 sm:gap-3 bg-surface-low border border-outline-variant/30 text-on-surface px-2 py-1 sm:px-3 sm:py-1.5 transition-all duration-200 hover:bg-surface-mid ghost-border"
               >
                 {profile?.avatar_url ? (
                   <img src={profile.avatar_url} referrerPolicy="no-referrer" alt="Profile" className="w-7 h-7 object-cover grayscale-[0.5] contrast-125 border border-neon/30" />
@@ -113,8 +113,8 @@ export default function Navbar() {
                     {profile?.full_name?.charAt(0) || 'U'}
                   </div>
                 )}
-                <span className="text-sm font-[family-name:var(--font-mono)] tracking-wider mr-1 uppercase">
-                  {profile?.full_name ? profile.full_name.split(' ')[0] : 'SESSION'}
+                <span className="text-xs sm:text-sm font-[family-name:var(--font-mono)] tracking-wider mr-1 uppercase truncate max-w-[60px] sm:max-w-[100px] inline-block align-bottom" title={profile?.full_name?.split(' ')[0] || 'DEV'}>
+                  {profile?.full_name ? profile.full_name.split(' ')[0] : 'DEV'}
                 </span>
               </button>
 

--- a/src/index.css
+++ b/src/index.css
@@ -105,7 +105,12 @@ body {
 }
 
 /* ── TYPOGRAPHY SYSTEM ── */
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: var(--font-display);
   font-weight: 700;
   letter-spacing: -0.03em;
@@ -117,9 +122,11 @@ h1, h2, h3, h4, h5, h6 {
 ::-webkit-scrollbar {
   width: 4px;
 }
+
 ::-webkit-scrollbar-track {
   background: var(--color-surface-lowest);
 }
+
 ::-webkit-scrollbar-thumb {
   background: var(--color-outline-variant);
 }
@@ -138,11 +145,9 @@ h1, h2, h3, h4, h5, h6 {
 
 /* ── DOT GRID BACKGROUND ── */
 .dot-grid {
-  background-image: radial-gradient(
-    circle,
-    var(--color-outline-variant) 1px,
-    transparent 1px
-  );
+  background-image: radial-gradient(circle,
+      var(--color-outline-variant) 1px,
+      transparent 1px);
   background-size: 24px 24px;
   opacity: 0.06;
 }
@@ -191,34 +196,80 @@ h1, h2, h3, h4, h5, h6 {
 
 /* ── ANIMATIONS ── */
 @keyframes scan-line {
-  0% { transform: translateY(-100%); }
-  100% { transform: translateY(100%); }
+  0% {
+    transform: translateY(-100%);
+  }
+
+  100% {
+    transform: translateY(100%);
+  }
 }
-.scan-line { animation: scan-line 2.5s ease-in-out infinite; }
+
+.scan-line {
+  animation: scan-line 2.5s ease-in-out infinite;
+}
 
 @keyframes pulse-glow {
-  0%, 100% { box-shadow: 0 0 12px rgba(195, 244, 0, 0.1); }
-  50% { box-shadow: 0 0 28px rgba(195, 244, 0, 0.25); }
+
+  0%,
+  100% {
+    box-shadow: 0 0 12px rgba(195, 244, 0, 0.1);
+  }
+
+  50% {
+    box-shadow: 0 0 28px rgba(195, 244, 0, 0.25);
+  }
 }
-.pulse-glow { animation: pulse-glow 2.5s ease-in-out infinite; }
+
+.pulse-glow {
+  animation: pulse-glow 2.5s ease-in-out infinite;
+}
 
 @keyframes concentric-pulse {
-  0% { transform: scale(1); opacity: 0.6; }
-  100% { transform: scale(2.5); opacity: 0; }
+  0% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+
+  100% {
+    transform: scale(2.5);
+    opacity: 0;
+  }
 }
 
 @keyframes data-stream {
-  0% { opacity: 0.3; }
-  50% { opacity: 1; }
-  100% { opacity: 0.3; }
+  0% {
+    opacity: 0.3;
+  }
+
+  50% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0.3;
+  }
 }
-.data-stream { animation: data-stream 1.5s ease-in-out infinite; }
+
+.data-stream {
+  animation: data-stream 1.5s ease-in-out infinite;
+}
 
 @keyframes fade-in-up {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
-.animate-in { animation: fade-in-up 0.6s ease-out forwards; }
+
+.animate-in {
+  animation: fade-in-up 0.6s ease-out forwards;
+}
 
 /* ── VIEWFINDER CORNER BRACKETS ── */
 .viewfinder-corner {
@@ -227,14 +278,43 @@ h1, h2, h3, h4, h5, h6 {
   height: 28px;
   border-color: var(--color-secondary);
 }
-.viewfinder-corner.top-left { top: 0; left: 0; border-top: 2px solid; border-left: 2px solid; }
-.viewfinder-corner.top-right { top: 0; right: 0; border-top: 2px solid; border-right: 2px solid; }
-.viewfinder-corner.bottom-left { bottom: 0; left: 0; border-bottom: 2px solid; border-left: 2px solid; }
-.viewfinder-corner.bottom-right { bottom: 0; right: 0; border-bottom: 2px solid; border-right: 2px solid; }
+
+.viewfinder-corner.top-left {
+  top: 0;
+  left: 0;
+  border-top: 2px solid;
+  border-left: 2px solid;
+}
+
+.viewfinder-corner.top-right {
+  top: 0;
+  right: 0;
+  border-top: 2px solid;
+  border-right: 2px solid;
+}
+
+.viewfinder-corner.bottom-left {
+  bottom: 0;
+  left: 0;
+  border-bottom: 2px solid;
+  border-left: 2px solid;
+}
+
+.viewfinder-corner.bottom-right {
+  bottom: 0;
+  right: 0;
+  border-bottom: 2px solid;
+  border-right: 2px solid;
+}
 
 /* ── FRESHNESS BAR ── */
-.freshness-bar-fresh { border-left: 4px solid var(--color-secondary); }
-.freshness-bar-spoiled { border-left: 4px solid var(--color-error); }
+.freshness-bar-fresh {
+  border-left: 4px solid var(--color-secondary);
+}
+
+.freshness-bar-spoiled {
+  border-left: 4px solid var(--color-error);
+}
 
 /* ── INPUT FIELDS ── */
 input[type="text"],
@@ -270,14 +350,21 @@ input::placeholder {
   letter-spacing: 0.05em;
 }
 
-.no-scrollbar::-webkit-scrollbar { display: none; }
-.no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
 
 /* ── LEAFLET BRUTALIST OVERRIDES ── */
 .leaflet-container {
   background: var(--color-bg-void) !important;
   font-family: var(--font-mono) !important;
 }
+
 .brutalist-popup .leaflet-popup-content-wrapper {
   background: var(--color-surface-mid) !important;
   color: var(--color-on-surface) !important;
@@ -285,6 +372,7 @@ input::placeholder {
   box-shadow: 0 0 0 1px var(--color-outline-variant) !important;
   padding: 0 !important;
 }
+
 .brutalist-popup .leaflet-popup-tip {
   background: var(--color-surface-mid) !important;
   box-shadow: none !important;
@@ -292,8 +380,15 @@ input::placeholder {
   border-top: none !important;
   border-left: none !important;
 }
-.brutalist-popup .leaflet-popup-content { margin: 0 !important; }
-.custom-leaflet-icon { background: transparent !important; border: none !important; }
+
+.brutalist-popup .leaflet-popup-content {
+  margin: 0 !important;
+}
+
+.custom-leaflet-icon {
+  background: transparent !important;
+  border: none !important;
+}
 
 :root.light {
   --bg: #ffffff;

--- a/src/index.css
+++ b/src/index.css
@@ -6,9 +6,13 @@
    Brutalist. Zero-radius. High-contrast neon.
    ========================================================= */
 
-/* ── THEME TOKENS (from Stitch: NEON NEURAL) ── */
+/* ── THEME TOKENS ── */
 @theme {
-  --color-bg: #131313;
+  /* Mapping tokens to CSS variables */
+  --color-bg: var(--bg);
+  --color-on-surface: var(--on-surface);
+  --color-heading: var(--heading-color);
+
   --color-bg-void: #000000;
   --color-surface: #131313;
   --color-surface-lowest: #0e0e0e;
@@ -26,7 +30,6 @@
   --color-secondary: #b5d25e;
   --color-secondary-container: #5d7602;
 
-  --color-on-surface: #e2e2e2;
   --color-on-surface-variant: #c4c9ac;
   --color-on-primary: #283500;
 
@@ -43,6 +46,19 @@
   --font-mono: 'Space Mono', 'Space Grotesk', ui-monospace, monospace;
 }
 
+/* ── DYNAMIC THEME VARIABLES ── */
+:root {
+  --bg: #131313;
+  --on-surface: #e2e2e2;
+  --heading-color: #ffffff;
+}
+
+:root.light {
+  --bg: #ffffff;
+  --on-surface: #121212;
+  --heading-color: #121212;
+}
+
 /* ── GLOBAL RESET: ZERO RADIUS ── */
 *,
 *::before,
@@ -55,6 +71,7 @@ html {
   font-family: var(--font-body);
   background-color: var(--color-bg);
   color: var(--color-on-surface);
+  transition: background-color 0.3s, color 0.3s;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
@@ -80,7 +97,7 @@ h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-display);
   font-weight: 700;
   letter-spacing: -0.03em;
-  color: var(--color-tertiary);
+  color: var(--color-heading);
   margin: 0;
 }
 
@@ -160,68 +177,36 @@ h1, h2, h3, h4, h5, h6 {
   background: linear-gradient(135deg, #ffffff 0%, #c3f400 100%);
 }
 
-/* ── SCAN LINE ANIMATION ── */
+/* ── ANIMATIONS ── */
 @keyframes scan-line {
   0% { transform: translateY(-100%); }
   100% { transform: translateY(100%); }
 }
+.scan-line { animation: scan-line 2.5s ease-in-out infinite; }
 
-.scan-line {
-  animation: scan-line 2.5s ease-in-out infinite;
-}
-
-/* ── PULSE GLOW ── */
 @keyframes pulse-glow {
-  0%, 100% {
-    box-shadow: 0 0 12px rgba(195, 244, 0, 0.1);
-  }
-  50% {
-    box-shadow: 0 0 28px rgba(195, 244, 0, 0.25);
-  }
+  0%, 100% { box-shadow: 0 0 12px rgba(195, 244, 0, 0.1); }
+  50% { box-shadow: 0 0 28px rgba(195, 244, 0, 0.25); }
 }
+.pulse-glow { animation: pulse-glow 2.5s ease-in-out infinite; }
 
-.pulse-glow {
-  animation: pulse-glow 2.5s ease-in-out infinite;
-}
-
-/* ── CONCENTRIC PULSE (Map Markers) ── */
 @keyframes concentric-pulse {
-  0% {
-    transform: scale(1);
-    opacity: 0.6;
-  }
-  100% {
-    transform: scale(2.5);
-    opacity: 0;
-  }
+  0% { transform: scale(1); opacity: 0.6; }
+  100% { transform: scale(2.5); opacity: 0; }
 }
 
-/* ── DATA STREAM ── */
 @keyframes data-stream {
   0% { opacity: 0.3; }
   50% { opacity: 1; }
   100% { opacity: 0.3; }
 }
+.data-stream { animation: data-stream 1.5s ease-in-out infinite; }
 
-.data-stream {
-  animation: data-stream 1.5s ease-in-out infinite;
-}
-
-/* ── FADE IN UP ── */
 @keyframes fade-in-up {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
 }
-
-.animate-in {
-  animation: fade-in-up 0.6s ease-out forwards;
-}
+.animate-in { animation: fade-in-up 0.6s ease-out forwards; }
 
 /* ── VIEWFINDER CORNER BRACKETS ── */
 .viewfinder-corner {
@@ -230,36 +215,16 @@ h1, h2, h3, h4, h5, h6 {
   height: 28px;
   border-color: var(--color-secondary);
 }
-.viewfinder-corner.top-left {
-  top: 0; left: 0;
-  border-top: 2px solid;
-  border-left: 2px solid;
-}
-.viewfinder-corner.top-right {
-  top: 0; right: 0;
-  border-top: 2px solid;
-  border-right: 2px solid;
-}
-.viewfinder-corner.bottom-left {
-  bottom: 0; left: 0;
-  border-bottom: 2px solid;
-  border-left: 2px solid;
-}
-.viewfinder-corner.bottom-right {
-  bottom: 0; right: 0;
-  border-bottom: 2px solid;
-  border-right: 2px solid;
-}
+.viewfinder-corner.top-left { top: 0; left: 0; border-top: 2px solid; border-left: 2px solid; }
+.viewfinder-corner.top-right { top: 0; right: 0; border-top: 2px solid; border-right: 2px solid; }
+.viewfinder-corner.bottom-left { bottom: 0; left: 0; border-bottom: 2px solid; border-left: 2px solid; }
+.viewfinder-corner.bottom-right { bottom: 0; right: 0; border-bottom: 2px solid; border-right: 2px solid; }
 
 /* ── FRESHNESS BAR ── */
-.freshness-bar-fresh {
-  border-left: 4px solid var(--color-secondary);
-}
-.freshness-bar-spoiled {
-  border-left: 4px solid var(--color-error);
-}
+.freshness-bar-fresh { border-left: 4px solid var(--color-secondary); }
+.freshness-bar-spoiled { border-left: 4px solid var(--color-error); }
 
-/* ── INPUT FIELDS (bottom-border only) ── */
+/* ── INPUT FIELDS ── */
 input[type="text"],
 input[type="email"],
 input[type="password"],
@@ -293,7 +258,6 @@ input::placeholder {
   letter-spacing: 0.05em;
 }
 
-/* ── UTILITY: No Scrollbar ── */
 .no-scrollbar::-webkit-scrollbar { display: none; }
 .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
 
@@ -316,10 +280,5 @@ input::placeholder {
   border-top: none !important;
   border-left: none !important;
 }
-.brutalist-popup .leaflet-popup-content {
-  margin: 0 !important;
-}
-.custom-leaflet-icon {
-  background: transparent !important;
-  border: none !important;
-}
+.brutalist-popup .leaflet-popup-content { margin: 0 !important; }
+.custom-leaflet-icon { background: transparent !important; border: none !important; }

--- a/src/index.css
+++ b/src/index.css
@@ -282,3 +282,20 @@ input::placeholder {
 }
 .brutalist-popup .leaflet-popup-content { margin: 0 !important; }
 .custom-leaflet-icon { background: transparent !important; border: none !important; }
+
+:root.light {
+  --bg: #ffffff;
+  --on-surface: #121212;
+  --heading-color: #121212;
+  /* Surface and border tokens for light mode readability */
+  --color-surface: #f7f7f7;
+  --color-surface-lowest: #ffffff;
+  --color-surface-low: #f2f2f2;
+  --color-surface-mid: #e8e8e8;
+  --color-surface-high: #dedede;
+  --color-surface-highest: #d4d4d4;
+  --color-on-surface-variant: #3d3d3d;
+  --color-outline: #6b6b6b;
+  --color-outline-variant: #c9c9c9;
+  --color-tertiary: #121212;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -54,9 +54,21 @@
 }
 
 :root.light {
-  --bg: #ffffff;
+  --bg: #f5f5f5;
   --on-surface: #121212;
   --heading-color: #121212;
+  --color-bg-void: #e8e8e8;
+  --color-surface: #f5f5f5;
+  --color-surface-lowest: #ebebeb;
+  --color-surface-low: #e8e8e8;
+  --color-surface-mid: #e0e0e0;
+  --color-surface-high: #d4d4d4;
+  --color-surface-highest: #cacaca;
+  --color-surface-bright: #c2c2c2;
+  --color-on-surface-variant: #3a3d2e;
+  --color-outline: #5c6048;
+  --color-outline-variant: #b0b59a;
+  --color-tertiary: #121212;
 }
 
 /* ── GLOBAL RESET: ZERO RADIUS ── */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -39,19 +39,21 @@ function authHeaders(): Record<string, string> {
 
 // ── Shared Error Handling Logic ──────────────────────────────────────────────
 
+// ── Shared Error Handling Logic ──────────────────────────────────────────────
+
 async function handleResponse(res: Response): Promise<Response> {
   if (res.ok) return res;
 
   // Handle 5xx errors (Server Side)
   if (res.status >= 500) {
-    toast.error("Server error. Please try again later.");
-  } else {
-    // Handle 4xx errors
-    const err = await res.json().catch(() => ({ detail: res.statusText }));
-    throw new Error((err as { detail?: string }).detail || `HTTP ${res.status}`);
+    const msg = "Server error. Please try again later.";
+    toast.error(msg);
+    throw new Error(msg); 
   }
   
-  throw new Error(`HTTP ${res.status}`);
+  // Handle 4xx errors
+  const err = await res.json().catch(() => ({ detail: res.statusText }));
+  throw new Error((err as { detail?: string }).detail || `HTTP ${res.status}`);
 }
 
 // Reusable wrapper to catch network-level drops

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -54,27 +54,30 @@ async function handleResponse(res: Response): Promise<Response> {
   throw new Error(`HTTP ${res.status}`);
 }
 
-async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+// Reusable wrapper to catch network-level drops
+async function safeFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   try {
-    const res = await fetch(`${API_BASE}${path}`, {
-      ...options,
-      headers: {
-        'Content-Type': 'application/json',
-        ...authHeaders(),
-        ...(options.headers as Record<string, string> || {}),
-      },
-    });
-
-    const validRes = await handleResponse(res);
-    return validRes.json() as Promise<T>;
+    const res = await fetch(input, init);
+    return await handleResponse(res);
   } catch (error) {
-    // Catch network-level drops (e.g., ERR_CONNECTION_REFUSED)
     if (error instanceof TypeError) {
       toast.error("Unable to connect to the server. Please check your internet connection.");
     }
     console.error("API Error:", error);
     throw error;
   }
+}
+
+async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const validRes = await safeFetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(),
+      ...(options.headers as Record<string, string> || {}),
+    },
+  });
+  return validRes.json() as Promise<T>;
 }
 
 // ── Response envelopes ────────────────────────────────────────────────────────
@@ -91,18 +94,17 @@ export const api = {
 
   getMe: (): Promise<UserProfile> => apiFetch<UserProfile>('/api/v1/auth/me'),
 
-  // Scans - Using native fetch with shared handleResponse to accommodate FormData
+  // Scans - Using safeFetch to ensure network errors are caught
   submitScan: async (blob: Blob): Promise<ScanResponse> => {
     const form = new FormData();
     form.append('image', blob, 'scan.jpg');
 
-    const res = await fetch(`${API_BASE}/api/v1/scan-auto`, {
+    const validRes = await safeFetch(`${API_BASE}/api/v1/scan-auto`, {
       method: 'POST',
       headers: authHeaders(),
       body: form,
     });
 
-    const validRes = await handleResponse(res);
     return validRes.json() as Promise<ScanResponse>;
   },
 
@@ -111,18 +113,17 @@ export const api = {
   getScanHistory: (limit = 20, offset = 0): Promise<HistoryResponse> => 
     apiFetch<HistoryResponse>(`/api/v1/scans/history?limit=${limit}&offset=${offset}`),
 
-  // Grad-CAM - Using native fetch with shared handleResponse
+  // Grad-CAM - Using safeFetch to ensure network errors are caught
   getGradcam: async (blob: Blob): Promise<GradcamResponse> => {
     const form = new FormData();
     form.append('image', blob, 'gradcam_input.jpg');
 
-    const res = await fetch(`${API_BASE}/api/v1/gradcam`, {
+    const validRes = await safeFetch(`${API_BASE}/api/v1/gradcam`, {
       method: 'POST',
       headers: authHeaders(),
       body: form,
     });
 
-    const validRes = await handleResponse(res);
     return validRes.json() as Promise<GradcamResponse>;
   },
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,4 @@
+import toast from 'react-hot-toast';
 import type {
   ScanResult,
   HistoryScan,
@@ -36,62 +37,61 @@ function authHeaders(): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-// ── Core fetch wrapper ────────────────────────────────────────────────────────
+// ── Shared Error Handling Logic ──────────────────────────────────────────────
 
-async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...authHeaders(),
-      ...(options.headers as Record<string, string> || {}),
-    },
-  });
+async function handleResponse(res: Response): Promise<Response> {
+  if (res.ok) return res;
 
-  if (!res.ok) {
+  // Handle 5xx errors (Server Side)
+  if (res.status >= 500) {
+    toast.error("Server error. Please try again later.");
+  } else {
+    // Handle 4xx errors
     const err = await res.json().catch(() => ({ detail: res.statusText }));
     throw new Error((err as { detail?: string }).detail || `HTTP ${res.status}`);
   }
+  
+  throw new Error(`HTTP ${res.status}`);
+}
 
-  return res.json() as Promise<T>;
+async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  try {
+    const res = await fetch(`${API_BASE}${path}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders(),
+        ...(options.headers as Record<string, string> || {}),
+      },
+    });
+
+    const validRes = await handleResponse(res);
+    return validRes.json() as Promise<T>;
+  } catch (error) {
+    // Catch network-level drops (e.g., ERR_CONNECTION_REFUSED)
+    if (error instanceof TypeError) {
+      toast.error("Unable to connect to the server. Please check your internet connection.");
+    }
+    console.error("API Error:", error);
+    throw error;
+  }
 }
 
 // ── Response envelopes ────────────────────────────────────────────────────────
 
-export interface ScanResponse {
-  success: boolean;
-  scan: ScanResult;
-}
-
-export interface HistoryResponse {
-  success: boolean;
-  count: number;
-  stats: HistoryStats;
-  scans: HistoryScan[];
-}
-
-export interface MarketsResponse {
-  success: boolean;
-  markets: Market[];
-}
-
-export interface GradcamResponse {
-  gradcam_image: string;   // base64 data-URI
-  predicted_class: string;
-  class_index: number;   // 0 | 1 | 2
-  mode: 'real' | 'demo';
-}
+export interface ScanResponse { success: boolean; scan: ScanResult; }
+export interface HistoryResponse { success: boolean; count: number; stats: HistoryStats; scans: HistoryScan[]; }
+export interface MarketsResponse { success: boolean; markets: Market[]; }
+export interface GradcamResponse { gradcam_image: string; predicted_class: string; class_index: number; mode: 'real' | 'demo'; }
 
 // ── API surface ───────────────────────────────────────────────────────────────
 
 export const api = {
-  // Auth
   loginUrl: (): string => `${API_BASE}/api/v1/auth/login/google`,
 
-  getMe: (): Promise<UserProfile> =>
-    apiFetch<UserProfile>('/api/v1/auth/me'),
+  getMe: (): Promise<UserProfile> => apiFetch<UserProfile>('/api/v1/auth/me'),
 
-  // Scans
+  // Scans - Using native fetch with shared handleResponse to accommodate FormData
   submitScan: async (blob: Blob): Promise<ScanResponse> => {
     const form = new FormData();
     form.append('image', blob, 'scan.jpg');
@@ -102,24 +102,16 @@ export const api = {
       body: form,
     });
 
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({ detail: res.statusText }));
-      throw new Error((err as { detail?: string }).detail || `HTTP ${res.status}`);
-    }
-
-    return res.json() as Promise<ScanResponse>;
+    const validRes = await handleResponse(res);
+    return validRes.json() as Promise<ScanResponse>;
   },
 
-  getLatestScan: (): Promise<ScanResponse> =>
-    apiFetch<ScanResponse>('/api/v1/scans/latest'),
-
-  getScan: (id: string): Promise<ScanResponse> =>
-    apiFetch<ScanResponse>(`/api/v1/scans/${id}`),
-
-  getScanHistory: (limit = 20, offset = 0): Promise<HistoryResponse> =>
+  getLatestScan: (): Promise<ScanResponse> => apiFetch<ScanResponse>('/api/v1/scans/latest'),
+  getScan: (id: string): Promise<ScanResponse> => apiFetch<ScanResponse>(`/api/v1/scans/${id}`),
+  getScanHistory: (limit = 20, offset = 0): Promise<HistoryResponse> => 
     apiFetch<HistoryResponse>(`/api/v1/scans/history?limit=${limit}&offset=${offset}`),
 
-  // Grad-CAM
+  // Grad-CAM - Using native fetch with shared handleResponse
   getGradcam: async (blob: Blob): Promise<GradcamResponse> => {
     const form = new FormData();
     form.append('image', blob, 'gradcam_input.jpg');
@@ -130,15 +122,9 @@ export const api = {
       body: form,
     });
 
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({ detail: res.statusText }));
-      throw new Error((err as { detail?: string }).detail || `HTTP ${res.status}`);
-    }
-
-    return res.json() as Promise<GradcamResponse>;
+    const validRes = await handleResponse(res);
+    return validRes.json() as Promise<GradcamResponse>;
   },
 
-  // Map
-  getMarkets: (): Promise<MarketsResponse> =>
-    apiFetch<MarketsResponse>('/api/v1/maps/markets'),
+  getMarkets: (): Promise<MarketsResponse> => apiFetch<MarketsResponse>('/api/v1/maps/markets'),
 };

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,13 @@
+// src/lib/theme.ts
+export const toggleTheme = () => {
+  const isLight = document.documentElement.classList.toggle('light');
+  localStorage.setItem('theme', isLight ? 'light' : 'dark');
+};
+
+export const initTheme = () => {
+  const savedTheme = localStorage.getItem('theme');
+  // Apply saved preference, or default to dark mode
+  if (savedTheme === 'light') {
+    document.documentElement.classList.add('light');
+  }
+};

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,13 +1,34 @@
-// src/lib/theme.ts
 export const toggleTheme = () => {
   const isLight = document.documentElement.classList.toggle('light');
-  localStorage.setItem('theme', isLight ? 'light' : 'dark');
+  try {
+    localStorage.setItem('theme', isLight ? 'light' : 'dark');
+  } catch (e) {
+    console.warn("Unable to save theme preference:", e);
+  }
 };
 
 export const initTheme = () => {
-  const savedTheme = localStorage.getItem('theme');
-  // Apply saved preference, or default to dark mode
-  if (savedTheme === 'light') {
-    document.documentElement.classList.add('light');
+  try {
+    const savedTheme = localStorage.getItem('theme');
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    if (savedTheme === 'light') {
+      document.documentElement.classList.add('light');
+    } else if (savedTheme === 'dark') {
+      document.documentElement.classList.remove('light');
+    } else if (systemPrefersDark) {
+      document.documentElement.classList.remove('light');
+    } else {
+      // Default to light if that's the desired site baseline, 
+      // or add 'light' class if the site defaults to dark
+      document.documentElement.classList.add('light');
+    }
+  } catch (e) {
+    // If localStorage is blocked, fall back to system preference
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (!systemPrefersDark) {
+      document.documentElement.classList.add('light');
+    }
+    console.warn("Unable to read theme preference:", e);
   }
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,10 @@ import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
 import './index.css'
 import App from './App.tsx'
+import { initTheme } from './lib/theme';
+
+// Initialize theme before rendering the app to prevent flicker
+initTheme();
 
 // PostHog is only initialized when the key is present.
 // Contributors running locally without the key will have it silently disabled.

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -21,33 +21,43 @@ export default function AuthPage() {
     const error = params.get('error');
 
     if (error) {
-      Promise.resolve().then(() => {
-        setStatus('error');
-        setErrorMsg('Authentication failed. Please try again.');
-      });
+      setStatus('error');
+      setErrorMsg('Authentication failed. Please try again.');
       window.history.replaceState({}, '', '/auth');
       return;
     }
 
     if (accessToken) {
-      Promise.resolve().then(() => setStatus('processing'));
+      setStatus('processing');
       setToken(accessToken);
       window.history.replaceState({}, '', '/auth');
       navigate('/mode', { replace: true });
       return;
     }
 
-    // If already authenticated, skip straight to mode select
     if (isAuthenticated()) {
       navigate('/mode', { replace: true });
     }
   }, [navigate, posthog]);
 
   const handleGoogleLogin = () => {
-    window.location.href = api.loginUrl();
+    try {
+      setStatus('processing');
+      const loginUrl = api.loginUrl();
+      
+      if (!loginUrl) {
+        throw new Error("Login URL configuration missing");
+      }
+      
+      // Force full browser navigation for OAuth
+      window.location.href = loginUrl;
+    } catch (err) {
+      setStatus('error');
+      setErrorMsg('Could not initiate Google Login. Please check your network connection.');
+      console.error("Auth initiation failed:", err);
+    }
   };
 
-  /** Dev-only: skip OAuth entirely, store the bypass token, go straight to /mode */
   const handleDevLogin = () => {
     setToken(DEV_BYPASS_TOKEN);
     posthog?.identify('dev-user', { email: 'dev@local' });
@@ -55,7 +65,7 @@ export default function AuthPage() {
   };
 
   const terminalMessages = (() => {
-    if (status === 'processing') return ['AUTH_SUCCESS', 'REDIRECTING...'];
+    if (status === 'processing') return ['AUTH_INITIATED', 'REDIRECTING_TO_OAUTH...'];
     if (status === 'error') return ['AUTH_ERROR', 'RETRY_REQUIRED'];
     return ['AUTHENTICATION', 'PROTOCOL: OAUTH-SECURE'];
   })();
@@ -110,7 +120,6 @@ export default function AuthPage() {
             {status === 'processing' ? 'AUTHENTICATING...' : 'CONTINUE_WITH_GOOGLE'}
           </button>
 
-          {/* DEV ONLY — shown only when VITE_DEV_MODE=true in .env.local */}
           {IS_DEV_MODE && (
             <button
               type="button"
@@ -122,13 +131,6 @@ export default function AuthPage() {
               <span className="text-yellow-500/50 text-[10px]">[local only]</span>
             </button>
           )}
-        </div>
-
-        <div className="mt-12 pt-6 border-t border-outline-variant/15">
-          <StatusTerminal
-            messages={['SYS_STAT: ONLINE', 'UPTIME: 99.97%']}
-            className="justify-center mt-4"
-          />
         </div>
       </div>
     </div>

--- a/src/pages/MarketMapPage.tsx
+++ b/src/pages/MarketMapPage.tsx
@@ -7,6 +7,13 @@ import StatusTerminal from '../components/StatusTerminal';
 import { api } from '../lib/api';
 import type { Market } from '../lib/types';
 
+const TILE_DARK  = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+const TILE_LIGHT = 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
+
+function getActiveTile() {
+  return document.documentElement.classList.contains('light') ? TILE_LIGHT : TILE_DARK;
+}
+
 function getScoreColor(score: number) {
   return score >= 85 ? 'text-secondary' : score >= 70 ? 'text-neon' : 'text-error';
 }
@@ -37,6 +44,14 @@ export default function MarketMapPage() {
   const [selected, setSelected] = useState<Market | null>(null);
   const [loading, setLoading]   = useState(true);
   const [error, setError]       = useState('');
+  const [tileUrl, setTileUrl] = useState(getActiveTile);
+
+  // Watch for theme class changes on <html> without depending on custom events
+  useEffect(() => {
+    const observer = new MutationObserver(() => setTileUrl(getActiveTile()));
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
 
   const defaultPosition: [number, number] = [22.5726, 88.3639];
 
@@ -81,10 +96,7 @@ export default function MarketMapPage() {
           scrollWheelZoom={true}
           className="w-full h-full z-0"
         >
-          <TileLayer
-            url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
-            attribution="&copy; CARTO"
-          />
+          <TileLayer url={tileUrl} attribution="&copy; CARTO" />
           {markers.map(m => (
             <Marker
               key={m.id}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,20 @@
+// src/pages/NotFound.tsx
+import { Link } from 'react-router-dom';
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-4">
+      <h1 className="text-6xl font-bold text-gray-800 mb-4">404</h1>
+      <h2 className="text-2xl font-semibold text-gray-600 mb-6">Page Not Found</h2>
+      <p className="text-gray-500 mb-8">
+        Oops! The page you are looking for doesn't exist or has been moved.
+      </p>
+      <Link 
+        to="/" 
+        className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+      >
+        Return Home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
Description
This PR introduces a global theme-switching system to the FreshScan AI platform, allowing users to toggle between dark and light modes. This enhances accessibility and user experience by providing a high-contrast theme suited for different environments.

Key Changes
Theme Utility: Created src/lib/theme.ts to manage theme state persistence using localStorage and system preference detection.

Dynamic Styling: Updated index.css to leverage CSS custom properties, ensuring all UI components respond automatically to theme changes.

Initialization: Integrated initTheme() in main.tsx to prevent "theme flashing" (flicker) when the page loads.

UI Integration: Added a centralized THEME toggle button to the Navbar, ensuring easy access across all pages.

Refinement: Optimized typography colors and glass-panel transparency to maintain readability and contrast in both modes.

Implementation Details
State Management: The theme selection is persisted in localStorage.

Design System: Utilized Tailwind's utility-first approach paired with CSS variables defined in the :root and :root.light selectors.

Layout: Cleaned up redundant UI elements by removing the floating toggle button, centralizing controls in the navigation bar for a cleaner aesthetic.

Verification
[x] Toggle functionality confirmed in both Chrome and Firefox.

[x] Theme choice persists across browser reloads.

[x] Contrast ratios checked for all main headings (e.g., "Fish Freshness") in light mode.

Screenshots
Dark Mode: 
<img width="959" height="524" alt="dark" src="https://github.com/user-attachments/assets/426661ce-5b0f-4845-b251-add48f5ba03d" />


Light Mode: 
<img width="957" height="538" alt="lightmode" src="https://github.com/user-attachments/assets/f19611bb-22b9-4824-8f32-8330b1fd9588" />


Closes #48

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global dark/light mode toggle with CSS variables and a Navbar button, plus dynamic map tile switching. Centralizes API error handling with global toasts and improves light-mode visuals and Navbar responsiveness.

- **New Features**
  - Theme toggle: persisted via `localStorage`, initialized early with `initTheme()` to prevent flash, and powered by CSS variables in `index.css` with expanded light-mode tokens.
  - Map tiles: auto-switch between CARTO dark/light `TileLayer` based on the active theme.
  - Global toasts: added `react-hot-toast` and `<Toaster />` in `App.tsx` for network/server error notifications.
  - 404 page: added a catch-all Not Found route and page.

- **Refactors**
  - API: introduced `safeFetch()` and `handleResponse()` in `src/lib/api.ts`; uploads and Grad-CAM now share consistent error handling with toast messages on 5xx and network drops.
  - UI: refined light-mode surface/outline colors and heading/body transitions; compact, responsive Navbar that groups THEME and auth controls.

<sup>Written for commit 6b1cb363274b0de864b9bd7564a4379889c97a41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jpdevhub/FreshScanAi/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

