### PR TITLE
fix: fix navbar element overlapping on mobile devices (< 768px) #72

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "framer-motion": "^12.38.0",

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -60,7 +60,7 @@ export default function Navbar() {
 
   return (
     <nav className="glass-panel fixed top-0 left-0 right-0 z-50 border-b border-outline-variant/15">
-      <div className="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
+      <div className="max-w-7xl mx-auto px-3 sm:px-6 h-16 flex items-center justify-between gap-2">
         {/* Logo */}
         <Link to="/" className="flex items-center gap-3 no-underline">
           <img
@@ -137,12 +137,13 @@ export default function Navbar() {
               )}
             </div>
           ) : (
-            <Link
+           <Link
               to="/auth"
-              className="flex items-center gap-2 bg-neon text-on-primary px-3 py-1.5 md:px-5 md:py-2.5 font-[family-name:var(--font-display)] font-bold text-xs md:text-sm tracking-wide no-underline transition-all duration-200 hover:bg-neon-dim"
-            >
-              SIGN_IN / SIGN_UP
-            </Link>
+              className="flex items-center gap-1 bg-neon text-on-primary px-2 py-1 md:px-5 md:py-2.5 font-[family-name:var(--font-display)] font-bold text-[10px] md:text-sm tracking-wide no-underline transition-all duration-200 hover:bg-neon-dim whitespace-nowrap"
+              >
+              <span className="hidden sm:inline">SIGN_IN / SIGN_UP</span>
+              <span className="sm:hidden">LOGIN</span>
+          </Link>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Description

Fixes #72

Fixed navbar elements overlapping on mobile devices (< 768px).

## Changes Made
- Reduced horizontal padding on navbar container for small screens
- Added `whitespace-nowrap` to prevent button wrapping
- Replaced "SIGN_IN / SIGN_UP" with "LOGIN" on mobile (< 640px) using responsive spans
- Navbar now fits cleanly at 375px without any overlap

## Checklist
- [x] `npm run lint` passes with no errors
- [x] `npm run build` compiles without TypeScript errors
- [x] No `.env` files, API keys, secrets in this diff
- [x] Branch is rebased on `main`, not merged