### PR TITLE
fix: add orphan image cleanup function

### DIFF
--- a/backend/supabase/functions/cleanup-orphan-images/README.md
+++ b/backend/supabase/functions/cleanup-orphan-images/README.md
@@ -1,0 +1,6 @@
+# Cleanup Orphan Images
+
+Deletes images from scan-images bucket if:
+
+- older than 24 hours
+- no matching record exists in scans table

--- a/backend/supabase/functions/cleanup-orphan-images/index.ts
+++ b/backend/supabase/functions/cleanup-orphan-images/index.ts
@@ -1,0 +1,46 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+);
+
+Deno.serve(async () => {
+  const bucket = "scan-images";
+
+  const { data: files, error } = await supabase.storage
+    .from(bucket)
+    .list("", { limit: 1000 });
+
+  if (error) {
+    return new Response(error.message, { status: 500 });
+  }
+
+  const now = Date.now();
+
+  for (const file of files ?? []) {
+    if (!file.created_at) continue;
+
+    const ageHours =
+      (now - new Date(file.created_at).getTime()) /
+      (1000 * 60 * 60);
+
+    if (ageHours < 24) continue;
+
+    const { data: scan } = await supabase
+      .from("scans")
+      .select("id")
+      .contains("photo_urls", [file.name])
+      .maybeSingle();
+
+    if (!scan) {
+      await supabase.storage
+        .from(bucket)
+        .remove([file.name]);
+
+      console.log(`Deleted orphan image: ${file.name}`);
+    }
+  }
+
+  return new Response("Cleanup completed");
+});


### PR DESCRIPTION
## Summary

Adds a Supabase Edge Function to automatically clean up orphaned images from the `scan-images` storage bucket.

## Changes Made

* Added `cleanup-orphan-images` Supabase Edge Function
* Identifies images older than 24 hours
* Checks for corresponding records in the `scans` table
* Removes orphaned files that are no longer referenced
* Added documentation for the cleanup process

## Issue

Fixes #5

## SSoC'26

This contribution was made as part of SSoC'26.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of orphaned images from storage. Images older than 24 hours with no associated records are now automatically deleted, improving storage efficiency and system maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->