### PR TITLE
feat(dashboard): add Grad-CAM heatmap overlay visualizer

### DIFF
--- a/src/pages/AnalysisDashboard.tsx
+++ b/src/pages/AnalysisDashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { ArrowLeft, AlertTriangle, Droplets, Eye as EyeIcon, Fish } from 'lucide-react';
+import { ArrowLeft, AlertTriangle, Droplets, Eye as EyeIcon, Fish, Loader2 } from 'lucide-react';
 import GlassCard from '../components/GlassCard';
 import StatusTerminal from '../components/StatusTerminal';
 import { api } from '../lib/api';
@@ -26,6 +26,14 @@ export default function AnalysisDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
+  const [gradcamImage, setGradcamImage] = useState<string | null>(null);
+  const [gradcamLoading, setGradcamLoading] = useState(false);
+  const [gradcamError, setGradcamError] = useState<string | null>(null);
+  const [blendOpacity, setBlendOpacity] = useState(0.5);
+  const [retryTrigger, setRetryTrigger] = useState(0);
+
+  const photo_url = scan?.photo_url;
+
   useEffect(() => {
     async function load() {
       setLoading(true);
@@ -48,6 +56,47 @@ export default function AnalysisDashboard() {
     }
     load();
   }, [params]);
+
+  useEffect(() => {
+    if (!photo_url) return;
+    const url = photo_url;
+
+    let isMounted = true;
+    async function loadGradcam() {
+      setGradcamLoading(true);
+      setGradcamError(null);
+      try {
+        const res = await fetch(url);
+        if (!res.ok) {
+          throw new Error(`Failed to download scan image (${res.status})`);
+        }
+        const blob = await res.blob();
+        const gradcamRes = await api.getGradcam(blob);
+        if (isMounted) {
+          setGradcamImage(gradcamRes.gradcam_image);
+        }
+      } catch (err) {
+        console.error('Grad-CAM generation error:', err);
+        if (isMounted) {
+          setGradcamError(err instanceof Error ? err.message : 'Heatmap generation failed.');
+        }
+      } finally {
+        if (isMounted) {
+          setGradcamLoading(false);
+        }
+      }
+    }
+
+    loadGradcam();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [photo_url, retryTrigger]);
+
+  const handleRetry = () => {
+    setRetryTrigger(prev => prev + 1);
+  };
 
   // ── Loading state ────────────────────────────────────────────────────────
   if (loading) {
@@ -102,96 +151,323 @@ export default function AnalysisDashboard() {
           className="mb-6"
         />
 
-        {/* Score + Species row */}
+        {/* Score + Species row / Visualization */}
         <div className="flex flex-col md:flex-row gap-6 mb-8">
-          {/* Main score card */}
-          <GlassCard className="flex-1 p-8 relative overflow-hidden" variant="tonal">
-            <div className="absolute top-4 right-4">
-              <span className="font-[family-name:var(--font-mono)] text-[0.5625rem] tracking-widest text-neon-text dark:text-neon-text text-neon-dark bg-surface-highest px-2 py-1">
-                GRADE_{grade}
-              </span>
-            </div>
+          {photo_url ? (
+            <>
+              {/* Left Column: Image Overlay Card */}
+              <GlassCard className="flex-1 p-6 flex flex-col gap-4 justify-between" variant="tonal">
+                <div>
+                  <span className="font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest text-on-surface-variant uppercase block mb-3">
+                    SCAN_VISUALIZATION
+                  </span>
 
-            <span className="font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest text-on-surface-variant uppercase block mb-2">
-              Freshness_Index
-            </span>
+                  {/* Stacked Images container */}
+                  <div className="relative w-full aspect-square bg-surface-lowest overflow-hidden border border-outline-variant/30 flex items-center justify-center">
+                    {/* Viewfinder corner brackets */}
+                    <div className="viewfinder-corner top-left z-20" />
+                    <div className="viewfinder-corner top-right z-20" />
+                    <div className="viewfinder-corner bottom-left z-20" />
+                    <div className="viewfinder-corner bottom-right z-20" />
 
-            <div className="flex items-baseline gap-2 mb-4">
-              <span className="font-[family-name:var(--font-display)] text-8xl md:text-9xl font-bold text-neon leading-none">
-                {freshness_index}
-              </span>
-              <span className="font-[family-name:var(--font-display)] text-2xl text-on-surface-variant font-bold">
-                /100
-              </span>
-            </div>
+                    {/* Base Original Image */}
+                    <img
+                      src={photo_url}
+                      alt="Original Fish Scan"
+                      className="w-full h-full object-cover"
+                    />
 
-            <div className="h-2 bg-surface-highest w-full mb-4">
-              <div
-                className="h-full bg-gradient-to-r from-neon-dim to-neon"
-                style={{ width: `${freshness_index}%` }}
-              />
-            </div>
+                    {/* Heatmap Overlay Image */}
+                    {gradcamImage && (
+                      <img
+                        src={gradcamImage}
+                        alt="GradCAM Heatmap Overlay"
+                        className="absolute inset-0 w-full h-full object-cover transition-opacity duration-150 ease-out z-10"
+                        style={{ opacity: blendOpacity }}
+                      />
+                    )}
 
-            <div className="flex items-center gap-4 flex-wrap">
-              <span className="font-[family-name:var(--font-mono)] text-[0.5625rem] text-secondary tracking-widest">
-                CLASSIFICATION: {classification}
-              </span>
+                    {/* Legend overlay */}
+                    {blendOpacity > 0 && gradcamImage && (
+                      <div className="absolute bottom-0 left-0 right-0 p-1.5 bg-black/60 flex items-center justify-center gap-1 z-25">
+                        {['#3b82f6', '#22c55e', '#eab308', '#ef4444'].map((c, i) => (
+                          <div key={i} className="w-6 h-2" style={{ background: c }} />
+                        ))}
+                        <span className="text-[0.5rem] text-white/60 font-[family-name:var(--font-mono)] ml-1">
+                          LOW → HIGH
+                        </span>
+                      </div>
+                    )}
 
-              <span className="font-[family-name:var(--font-mono)] text-[0.5625rem] text-on-surface-variant tracking-widest">
-                CONFIDENCE: {confidence}%
-              </span>
+                    {/* Loading overlay */}
+                    {gradcamLoading && (
+                      <div className="absolute inset-0 bg-surface-lowest/80 flex flex-col items-center justify-center gap-3 z-30">
+                        <Loader2 className="w-8 h-8 text-neon animate-spin" />
+                        <span className="font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest text-on-surface-variant">
+                          GENERATING_HEATMAP...
+                        </span>
+                      </div>
+                    )}
 
-              <span
-                className={`px-2 py-1 border text-xs font-semibold font-[family-name:var(--font-mono)] tracking-widest ${confidence < 70
-                    ? "text-error"
-                    : "text-neon"
-                  }`}
-              >
-                {confidence < 70 ? "LOW_CONFIDENCE" : "HIGH_CONFIDENCE"}
-              </span>
-            </div>
-          </GlassCard>
+                    {/* Error overlay */}
+                    {gradcamError && (
+                      <div className="absolute inset-0 bg-surface-lowest/95 flex flex-col items-center justify-center gap-2 p-4 text-center z-30">
+                        <AlertTriangle className="w-8 h-8 text-error" />
+                        <span className="font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest text-error">
+                          ACTIVATION_MAP_ERROR
+                        </span>
+                        <p className="text-xs text-on-surface-variant max-w-[200px] line-clamp-2">
+                          {gradcamError}
+                        </p>
+                        <button
+                          onClick={handleRetry}
+                          className="mt-2 px-3 py-1 bg-surface-high border border-outline-variant hover:border-neon hover:text-neon transition-colors text-[0.625rem] font-[family-name:var(--font-mono)] tracking-wider cursor-pointer"
+                        >
+                          RETRY
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
 
-          {/* Species panel */}
-          <GlassCard className="md:w-72 p-6" variant="glass">
-            <span className="font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest text-on-surface-variant uppercase block mb-4">
-              Detected_Specimen
-            </span>
+                <div className="flex flex-col gap-4">
+                  {/* Toggle Buttons */}
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setBlendOpacity(0)}
+                      className={`flex-1 py-2 font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest border border-outline-variant/30 cursor-pointer transition-colors ${
+                        blendOpacity === 0
+                          ? "bg-neon text-on-primary font-bold border-neon"
+                          : "bg-surface-mid text-on-surface-variant hover:text-on-surface"
+                      }`}
+                    >
+                      ORIGINAL
+                    </button>
+                    <button
+                      onClick={() => setBlendOpacity(0.5)}
+                      className={`flex-1 py-2 font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest border border-outline-variant/30 cursor-pointer transition-colors ${
+                        blendOpacity > 0 && blendOpacity < 1
+                          ? "bg-neon text-on-primary font-bold border-neon"
+                          : "bg-surface-mid text-on-surface-variant hover:text-on-surface"
+                      }`}
+                    >
+                      BLENDED
+                    </button>
+                    <button
+                      onClick={() => setBlendOpacity(1)}
+                      className={`flex-1 py-2 font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest border border-outline-variant/30 cursor-pointer transition-colors ${
+                        blendOpacity === 1
+                          ? "bg-neon text-on-primary font-bold border-neon"
+                          : "bg-surface-mid text-on-surface-variant hover:text-on-surface"
+                      }`}
+                    >
+                      HEATMAP
+                    </button>
+                  </div>
 
-            <div className="flex flex-wrap gap-2 mb-4">
-              {species.tags.map(tag => (
-                <span
-                  key={tag}
-                  className="bg-surface-highest text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.5625rem] tracking-widest px-3 py-1.5"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
+                  {/* Opacity slider */}
+                  <div className="flex flex-col gap-1.5">
+                    <div className="flex justify-between items-center text-[0.625rem] font-[family-name:var(--font-mono)] text-on-surface-variant">
+                      <span>BLEND LEVEL</span>
+                      <span className="text-neon font-bold">{Math.round(blendOpacity * 100)}%</span>
+                    </div>
+                    <input
+                      type="range"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      value={blendOpacity}
+                      onChange={(e) => setBlendOpacity(parseFloat(e.target.value))}
+                      className="w-full accent-neon bg-surface-lowest border border-outline-variant/30 cursor-pointer h-1.5 outline-none"
+                    />
+                  </div>
+                </div>
+              </GlassCard>
 
-            <div className="space-y-3 text-sm">
-              <div className="flex justify-between">
-                <span className="text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.625rem]">WEIGHT_EST</span>
-                <span className={`font-[family-name:var(--font-display)] font-semibold ${gradeColor(grade)}`}>
-                  ~{species.weight_estimate_kg} kg
-                </span>
+              {/* Right Column: Score & Species stacked */}
+              <div className="flex-1 flex flex-col gap-6">
+                {/* Main score card */}
+                <GlassCard className="p-8 relative overflow-hidden" variant="tonal">
+                  <div className="absolute top-4 right-4">
+                    <span className="font-[family-name:var(--font-mono)] text-[0.5625rem] tracking-widest text-neon-text dark:text-neon-text text-neon-dark bg-surface-highest px-2 py-1">
+                      GRADE_{grade}
+                    </span>
+                  </div>
+
+                  <span className="font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest text-on-surface-variant uppercase block mb-2">
+                    Freshness_Index
+                  </span>
+
+                  <div className="flex items-baseline gap-2 mb-4">
+                    <span className="font-[family-name:var(--font-display)] text-8xl md:text-9xl font-bold text-neon leading-none">
+                      {freshness_index}
+                    </span>
+                    <span className="font-[family-name:var(--font-display)] text-2xl text-on-surface-variant font-bold">
+                      /100
+                    </span>
+                  </div>
+
+                  <div className="h-2 bg-surface-highest w-full mb-4">
+                    <div
+                      className="h-full bg-gradient-to-r from-neon-dim to-neon"
+                      style={{ width: `${freshness_index}%` }}
+                    />
+                  </div>
+
+                  <div className="flex items-center gap-4 flex-wrap">
+                    <span className="font-[family-name:var(--font-mono)] text-[0.5625rem] text-secondary tracking-widest">
+                      CLASSIFICATION: {classification}
+                    </span>
+
+                    <span className="font-[family-name:var(--font-mono)] text-[0.5625rem] text-on-surface-variant tracking-widest">
+                      CONFIDENCE: {confidence}%
+                    </span>
+
+                    <span
+                      className={`px-2 py-1 border text-xs font-semibold font-[family-name:var(--font-mono)] tracking-widest ${confidence < 70
+                          ? "text-error"
+                          : "text-neon"
+                        }`}
+                    >
+                      {confidence < 70 ? "LOW_CONFIDENCE" : "HIGH_CONFIDENCE"}
+                    </span>
+                  </div>
+                </GlassCard>
+
+                {/* Species panel */}
+                <GlassCard className="p-6" variant="glass">
+                  <span className="font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest text-on-surface-variant uppercase block mb-4">
+                    Detected_Specimen
+                  </span>
+
+                  <div className="flex flex-wrap gap-2 mb-4">
+                    {species.tags.map(tag => (
+                      <span
+                        key={tag}
+                        className="bg-surface-highest text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.5625rem] tracking-widest px-3 py-1.5"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+
+                  <div className="space-y-3 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.625rem]">WEIGHT_EST</span>
+                      <span className={`font-[family-name:var(--font-display)] font-semibold ${gradeColor(grade)}`}>
+                        ~{species.weight_estimate_kg} kg
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.625rem]">CATCH_AGE</span>
+                      <span className={`font-[family-name:var(--font-display)] font-semibold ${gradeColor(grade)}`}>
+                        ~{species.catch_age_hours} hrs
+                      </span>
+                    </div>
+                    {scan.market_name && (
+                      <div className="flex justify-between">
+                        <span className="text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.625rem]">MARKET</span>
+                        <span className={`font-[family-name:var(--font-display)] font-semibold ${gradeColor(grade)}`}>
+                          {scan.market_name}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </GlassCard>
               </div>
-              <div className="flex justify-between">
-                <span className="text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.625rem]">CATCH_AGE</span>
-                <span className={`font-[family-name:var(--font-display)] font-semibold ${gradeColor(grade)}`}>
-                  ~{species.catch_age_hours} hrs
-                </span>
-              </div>
-              {scan.market_name && (
-                <div className="flex justify-between">
-                  <span className="text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.625rem]">MARKET</span>
-                  <span className={`font-[family-name:var(--font-display)] font-semibold ${gradeColor(grade)}`}>
-                    {scan.market_name}
+            </>
+          ) : (
+            <>
+              {/* Main score card */}
+              <GlassCard className="flex-1 p-8 relative overflow-hidden" variant="tonal">
+                <div className="absolute top-4 right-4">
+                  <span className="font-[family-name:var(--font-mono)] text-[0.5625rem] tracking-widest text-neon-text dark:text-neon-text text-neon-dark bg-surface-highest px-2 py-1">
+                    GRADE_{grade}
                   </span>
                 </div>
-              )}
-            </div>
-          </GlassCard>
+
+                <span className="font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest text-on-surface-variant uppercase block mb-2">
+                  Freshness_Index
+                </span>
+
+                <div className="flex items-baseline gap-2 mb-4">
+                  <span className="font-[family-name:var(--font-display)] text-8xl md:text-9xl font-bold text-neon leading-none">
+                    {freshness_index}
+                  </span>
+                  <span className="font-[family-name:var(--font-display)] text-2xl text-on-surface-variant font-bold">
+                    /100
+                  </span>
+                </div>
+
+                <div className="h-2 bg-surface-highest w-full mb-4">
+                  <div
+                    className="h-full bg-gradient-to-r from-neon-dim to-neon"
+                    style={{ width: `${freshness_index}%` }}
+                  />
+                </div>
+
+                <div className="flex items-center gap-4 flex-wrap">
+                  <span className="font-[family-name:var(--font-mono)] text-[0.5625rem] text-secondary tracking-widest">
+                    CLASSIFICATION: {classification}
+                  </span>
+
+                  <span className="font-[family-name:var(--font-mono)] text-[0.5625rem] text-on-surface-variant tracking-widest">
+                    CONFIDENCE: {confidence}%
+                  </span>
+
+                  <span
+                    className={`px-2 py-1 border text-xs font-semibold font-[family-name:var(--font-mono)] tracking-widest ${confidence < 70
+                        ? "text-error"
+                        : "text-neon"
+                      }`}
+                  >
+                    {confidence < 70 ? "LOW_CONFIDENCE" : "HIGH_CONFIDENCE"}
+                  </span>
+                </div>
+              </GlassCard>
+
+              {/* Species panel */}
+              <GlassCard className="md:w-72 p-6" variant="glass">
+                <span className="font-[family-name:var(--font-mono)] text-[0.625rem] tracking-widest text-on-surface-variant uppercase block mb-4">
+                  Detected_Specimen
+                </span>
+
+                <div className="flex flex-wrap gap-2 mb-4">
+                  {species.tags.map(tag => (
+                    <span
+                      key={tag}
+                      className="bg-surface-highest text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.5625rem] tracking-widest px-3 py-1.5"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+
+                <div className="space-y-3 text-sm">
+                  <div className="flex justify-between">
+                    <span className="text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.625rem]">WEIGHT_EST</span>
+                    <span className={`font-[family-name:var(--font-display)] font-semibold ${gradeColor(grade)}`}>
+                      ~{species.weight_estimate_kg} kg
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.625rem]">CATCH_AGE</span>
+                    <span className={`font-[family-name:var(--font-display)] font-semibold ${gradeColor(grade)}`}>
+                      ~{species.catch_age_hours} hrs
+                    </span>
+                  </div>
+                  {scan.market_name && (
+                    <div className="flex justify-between">
+                      <span className="text-on-surface-variant font-[family-name:var(--font-mono)] text-[0.625rem]">MARKET</span>
+                      <span className={`font-[family-name:var(--font-display)] font-semibold ${gradeColor(grade)}`}>
+                        {scan.market_name}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </GlassCard>
+            </>
+          )}
         </div>
 
         {/* Biomarkers — 3 model-native streams */}

--- a/src/pages/AnalysisDashboard.tsx
+++ b/src/pages/AnalysisDashboard.tsx
@@ -82,13 +82,17 @@ export default function AnalysisDashboard() {
     const url = photo_url;
 
     let isMounted = true;
+    const controller = new AbortController();
 
     async function loadGradcam() {
+      setGradcamImage(null);
       setGradcamLoading(true);
       setGradcamError(null);
 
       try {
-        const res = await fetch(url);
+        const res = await fetch(url, {
+        signal: controller.signal,
+        });
 
         if (!res.ok) {
           throw new Error(`Failed to download scan image (${res.status})`);
@@ -101,6 +105,13 @@ export default function AnalysisDashboard() {
           setGradcamImage(gradcamRes.gradcam_image);
         }
       } catch (err) {
+         if (
+        err instanceof DOMException &&
+        err.name === "AbortError"
+          ) {
+        return;
+        }
+
         console.error("Grad-CAM generation error:", err);
 
         if (isMounted) {
@@ -120,7 +131,8 @@ export default function AnalysisDashboard() {
     loadGradcam();
 
     return () => {
-      isMounted = false;
+    isMounted = false;
+    controller.abort();
     };
   }, [photo_url, retryTrigger]);
 
@@ -218,7 +230,7 @@ export default function AnalysisDashboard() {
 
                     {/* Legend overlay */}
                     {blendOpacity > 0 && gradcamImage && (
-                      <div className="absolute bottom-0 left-0 right-0 p-1.5 bg-black/60 flex items-center justify-center gap-1 z-25">
+                      <div className="absolute bottom-0 left-0 right-0 p-1.5 bg-black/60 flex items-center justify-center gap-1 z-30">
                         {['#3b82f6', '#22c55e', '#eab308', '#ef4444'].map((c, i) => (
                           <div key={i} className="w-6 h-2" style={{ background: c }} />
                         ))}


### PR DESCRIPTION
## Description
Closes #46
This PR resolves the issue by integrating the Grad-CAM activation map overlay visualization on the scan analysis page (`AnalysisDashboard.tsx`). 

Key changes:
- Retrieves `photo_url` from the scan result and fetches the image in the frontend, sending it to the backend `/api/v1/gradcam` endpoint to generate the Grad-CAM base64 JPEG heatmap.
- Dynamically splits the desktop layout when a photo is available to display a **Scan Visualization** card on the left and the **Score Card** / **Species Panel** stacked on the right. If no photo is available, falls back to the original side-by-side layout.
- Renders the scanned fish with viewfinder corners and stacks the Grad-CAM heatmap overlay on top of it.
- Added interactive controls to the visualization card:
  - **Toggles**: Quick-buttons to switch between **ORIGINAL** (0% opacity), **BLENDED** (50% opacity), and **HEATMAP** (100% opacity).
  - **Blend Slider**: A range slider to adjust opacity smoothly from 0% to 100%.
  - **Color Legend**: Shows a `LOW → HIGH` color gradient bar when the heatmap is visible.
  - **State Overlays**: Styled overlays for loading (spinner) and error (retry button) states.

## Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm run build` compiles without TypeScript errors
- [x] `python -m pytest` passes (including new tests I added)
- [x] No `.env` files, API keys, secrets, model weights, or `__pycache__` in this diff
- [x] Branch is rebased on `main`, not merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analysis Dashboard now displays Grad-CAM heatmap overlays when a photo is available, visualizing model attention areas.
  * Added blend opacity controls (toggle and slider) plus a legend for easier interpretation.
  * Improved analysis experience with loading states, error handling, and a retry action.
* **UI Updates**
  * Reworked the score/species area into a visualization-first layout when photos are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->