### PR TITLE
feat(api): add rate limiting to maps/markets endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -769,7 +769,8 @@ async def get_vendor_leaderboard():
 
 
 @app.get("/api/v1/maps/markets")
-async def get_markets():
+@limiter.limit("20/minute")
+async def get_markets(request: Request):
     try:
         resp = (
             _db()

--- a/backend/tests/test_rate_limiter.py
+++ b/backend/tests/test_rate_limiter.py
@@ -48,3 +48,4 @@ def test_maps_markets_not_rate_limited_initially():
     """First request to maps/markets should not be rate limited."""
     response = client.get("/api/v1/maps/markets")
     assert response.status_code != 429
+

--- a/backend/tests/test_rate_limiter.py
+++ b/backend/tests/test_rate_limiter.py
@@ -43,3 +43,8 @@ def test_rate_limit_retry_after_header():
     assert len(rate_limited) > 0
     body = rate_limited[0].json()
     assert body is not None
+
+def test_maps_markets_not_rate_limited_initially():
+    """First request to maps/markets should not be rate limited."""
+    response = client.get("/api/v1/maps/markets")
+    assert response.status_code != 429


### PR DESCRIPTION
## Description

Closes #91

The `/api/v1/maps/markets` endpoint was publicly accessible without any rate 
limiting. I had previously implemented rate limiting for this project (PR #83) 
which covered `/api/v1/scan` and `/api/v1/scan-auto`, but `/api/v1/maps/markets` 
was missed. This PR completes the coverage by adding `@limiter.limit("20/minute")` 
to that endpoint and a corresponding test in `tests/test_rate_limiter.py`.

No new dependencies were added — `slowapi` was already present from PR #83.

## Checklist

- [x] `npm run lint` passes with no errors
- [x] `npm run build` compiles without TypeScript errors
- [x] `python -m pytest` passes (including new tests I added)
- [x] No `.env` files, API keys, secrets, model weights, or `__pycache__` in this diff
- [x] Branch is rebased on `main`, not merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting is now enforced on the Markets API endpoint. Clients are limited to 20 requests per minute. Requests exceeding this limit will receive a rate limit response.

* **Tests**
  * Added regression test to verify that the Markets API endpoint does not apply rate limiting to the initial request from a client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->