### PR TITLE
feat: add CameraOverlay bounding box for live camera feed (closes #58)

### DIFF
--- a/src/components/CameraOverlay.tsx
+++ b/src/components/CameraOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 
 interface Props {
   active: boolean;

--- a/src/components/CameraOverlay.tsx
+++ b/src/components/CameraOverlay.tsx
@@ -1,0 +1,43 @@
+import React, { useRef, useEffect } from 'react';
+
+interface Props {
+  active: boolean;
+}
+
+export default function CameraOverlay({ active }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (!active) return;
+
+    const w = canvas.width;
+    const h = canvas.height;
+    const x = w * 0.1;
+    const y = h * 0.15;
+    const bw = w * 0.8;
+    const bh = h * 0.7;
+
+    ctx.strokeStyle = 'rgba(0, 255, 180, 0.75)';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([8, 4]);
+    ctx.strokeRect(x, y, bw, bh);
+
+    ctx.fillStyle = 'rgba(0, 255, 180, 0.15)';
+    ctx.fillRect(x, y, bw, bh);
+  }, [active]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={640}
+      height={480}
+      className="absolute inset-0 w-full h-full z-30 pointer-events-none"
+    />
+  );
+}

--- a/src/pages/ScannerPage.tsx
+++ b/src/pages/ScannerPage.tsx
@@ -10,6 +10,7 @@ import {
   Upload,
 } from "lucide-react";
 import StatusTerminal from "../components/StatusTerminal";
+import CameraOverlay from "../components/CameraOverlay";
 import { api, isAuthenticated } from "../lib/api";
 import { FishFreshnessInference } from "../fusionInference.js";
 import type { ScanResult } from "../lib/types";
@@ -469,6 +470,9 @@ export default function ScannerPage() {
               }`}
             />
           )}
+
+          {/* Camera Overlay Bounding Box */}
+          <CameraOverlay active={scanPhase === "idle"} />
 
           {/* Grid overlay */}
           <div


### PR DESCRIPTION

## Description

Closes #58

Added a `CameraOverlay` component that draws a dashed green bounding box over the live camera feed to help users frame the fish correctly before capturing.

### Changes
- New component: `src/components/CameraOverlay.tsx`
- Overlay is shown only during `idle` scan phase
- Uses HTML5 Canvas API for the framing guide

## Checklist
- [x] Branch is rebased on `main`, not merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual camera overlay to the scanner interface. The overlay appears when the scanner is idle, providing visual guidance to help users properly frame their camera for scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->