### PR TITLE
fix: increase edge inference confidence threshold to reject non-fish images

### DIFF
--- a/src/fusionInference.js
+++ b/src/fusionInference.js
@@ -51,7 +51,8 @@ const THRESHOLD_MODERATE = 0.35; // score >= 0.35 → Moderate, else Spoiled
 // the image is unlikely to be a fish (all-class uncertainty).
 // Note: the ONNX model was trained only on fish, so non-fish images may still
 // score above this — treat as a best-effort guard, not a hard detector.
-const NOT_A_FISH_THRESHOLD = 0.36;
+// Increased to 0.55 from 0.36 to better reject non-fish objects (e.g. human faces).
+const NOT_A_FISH_THRESHOLD = 0.55;
 
 // Default model paths (relative to Vite public/ folder)
 const DEFAULT_MODEL_PATHS = {


### PR DESCRIPTION
Resolves #99

### Problem Statement
When running the application in offline mode, taking a picture of a non-fish object (like a human face or generic object) often resulted in the app blindly accepting the image and returning a bogus "Fresh" score, rather than explicitly rejecting it. 

### Root Cause
The `NOT_A_FISH_THRESHOLD` in `src/fusionInference.js` was configured to `0.36`. Because the Stream A MobileNet model has 3 classes, pure random chance yields a baseline probability of `0.33`. This meant the threshold was so low that almost any out-of-distribution image's maximum class probability would pass the check, successfully bypassing the guardrail.

### Solution Implemented
- Increased `NOT_A_FISH_THRESHOLD` from `0.36` to `0.55`. 
- Added an explanatory comment above the constant.

This requires the model to be significantly more confident than random chance before accepting an image as a valid fish, effectively filtering out generic objects and faces without the payload overhead of downloading a secondary object-detection model.

### Testing Performed
- [x] Verified offline edge inference with various fish images successfully passes the new threshold.
- [x] Verified offline edge inference with non-fish objects (faces, coffee mugs) correctly falls below the 55% threshold and triggers the `NOT_A_FISH` error state.

### Potential Impacts
Very blurry or poorly lit legitimate fish images might occasionally fall below the 55% confidence threshold, requiring the user to rescan (which is the intended safe fallback behavior).
