### PR TITLE
feat(api): cache markets endpoint for 5 minutes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,9 @@ from turnstile import TURNSTILE_SECRET_KEY, verify_turnstile_token
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from rate_limiter import limiter
+from fastapi_cache import FastAPICache
+from fastapi_cache.backends.inmemory import InMemoryBackend
+from fastapi_cache.decorator import cache
 
 
 # Load .env file if present (python-dotenv)
@@ -93,6 +96,7 @@ async def lifespan(app: FastAPI):
             f"WARNING: Model files not found at {MODEL_DIR}. "
             "Scan endpoints will return 503 until models are present."
         )
+    FastAPICache.init(InMemoryBackend(), prefix="freshscanai-cache")
     yield
 
 
@@ -768,31 +772,35 @@ async def get_vendor_leaderboard():
 # ── MAP ───────────────────────────────────────────────────────────────────────
 
 
+@cache(expire=300, namespace="markets")
+async def _get_markets_cached() -> dict:
+    resp = (
+        _db()
+        .table("vendors")
+        .select("id, name, avg_freshness_score, trust_score, lat, lng, vendor_count")
+        .execute()
+    )
+    markets = [
+        {
+            "id": i + 1,
+            "name": v["name"],
+            "score": int(v.get("avg_freshness_score") or v.get("trust_score") or 0),
+            "lat": float(v.get("lat") or 0),
+            "lng": float(v.get("lng") or 0),
+            "vendors": int(v.get("vendor_count") or 1),
+        }
+        for i, v in enumerate(resp.data or [])
+        if v.get("lat") and v.get("lng")
+    ]
+    return {"success": True, "markets": markets}
+
+
 @app.get("/api/v1/maps/markets")
 @limiter.limit("20/minute")
 async def get_markets(request: Request):
     try:
-        resp = (
-            _db()
-            .table("vendors")
-            .select("id, name, avg_freshness_score, trust_score, lat, lng, vendor_count")
-            .execute()
-        )
-        markets = [
-            {
-                "id": i + 1,
-                "name": v["name"],
-                "score": int(v.get("avg_freshness_score") or v.get("trust_score") or 0),
-                "lat": float(v.get("lat") or 0),
-                "lng": float(v.get("lng") or 0),
-                "vendors": int(v.get("vendor_count") or 1),
-            }
-            for i, v in enumerate(resp.data or [])
-            if v.get("lat") and v.get("lng")
-        ]
-        return {"success": True, "markets": markets}
+        return await _get_markets_cached()
     except Exception:
-        # Migration not applied yet — return empty markets, map still renders
         return {
             "success": True,
             "markets": [],

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,5 @@ pytest>=8.0.0
 torch>=2.2.0
 torchvision>=0.27.0
 slowapi==0.1.9  # rate limiting for FastAPI; added for per-user scan endpoint throttling
+
+fastapi-cache2==0.2.2

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -1,0 +1,76 @@
+import asyncio
+
+import pytest
+from fastapi_cache import FastAPICache
+from fastapi_cache.backends.inmemory import InMemoryBackend
+from fastapi_cache.decorator import cache
+
+
+@pytest.fixture(autouse=True)
+def _init_cache():
+    FastAPICache.init(InMemoryBackend(), prefix="test-cache")
+    yield
+
+
+def test_cache_returns_same_value_within_ttl():
+    calls = {"count": 0}
+
+    @cache(expire=60, namespace="test_ns_1")
+    async def handler():
+        calls["count"] += 1
+        return {"value": calls["count"]}
+
+    first = asyncio.run(handler())
+    second = asyncio.run(handler())
+
+    assert first == {"value": 1}
+    assert second == {"value": 1}
+    assert calls["count"] == 1
+
+
+def test_cache_expires_after_ttl():
+    calls = {"count": 0}
+
+    @cache(expire=1, namespace="test_ns_2")
+    async def handler():
+        calls["count"] += 1
+        return {"value": calls["count"]}
+
+    asyncio.run(handler())
+    asyncio.run(asyncio.sleep(2.1))
+    second = asyncio.run(handler())
+
+    assert second == {"value": 2}
+    assert calls["count"] == 2
+
+
+def test_cache_clear_forces_recompute():
+    calls = {"count": 0}
+
+    @cache(expire=60, namespace="test_ns_3")
+    async def handler():
+        calls["count"] += 1
+        return {"value": calls["count"]}
+
+    asyncio.run(handler())
+    asyncio.run(FastAPICache.clear(namespace="test_ns_3"))
+    second = asyncio.run(handler())
+
+    assert second == {"value": 2}
+    assert calls["count"] == 2
+
+
+def test_exception_inside_cached_function_is_not_cached():
+    calls = {"count": 0}
+
+    @cache(expire=60, namespace="test_ns_4")
+    async def handler():
+        calls["count"] += 1
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        asyncio.run(handler())
+    with pytest.raises(ValueError):
+        asyncio.run(handler())
+
+    assert calls["count"] == 2

--- a/backend/vendors.py
+++ b/backend/vendors.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Depends, Query
 from datetime import datetime, timedelta, timezone
 from auth import get_current_user
+from fastapi_cache import FastAPICache
 
 router = APIRouter(prefix="/api/v1/vendors", tags=["vendors"])
 
@@ -127,6 +128,8 @@ def register_routes(router: APIRouter, db_getter):
                     "trend": trend,
                 }
             ).eq("id", vendor_id).execute()
+
+            await FastAPICache.clear(namespace="markets")
 
             return {
                 "success": True,


### PR DESCRIPTION
## Description

Closes #128.

Implements a 5-minute caching layer on the `/api/v1/maps/markets` endpoint to reduce database load on this frequently-hit route, as described in the issue.

**Approach:** `fastapi-cache2` with `InMemoryBackend`, as discussed in the issue thread — no Redis instance is currently provisioned on this repo's deployment target (HF Spaces/Render/Railway), so in-memory avoids adding new infra while still satisfying the issue's "Redis or In-Memory" requirement.

**Changes:**
- `backend/main.py`:
  - `FastAPICache.init(InMemoryBackend(), prefix="freshscanai-cache")` added to the existing `lifespan` context manager.
  - Split `get_markets` into a thin route handler (`get_markets`) and a cached helper (`_get_markets_cached`, decorated with `@cache(expire=300, namespace="markets")`). This split ensures the DB-failure fallback response is never cached — only successful DB reads are stored, so a transient Supabase error doesn't get served back for the full 5 minutes.
- `backend/vendors.py`:
  - `recalculate_trust_score` now calls `await FastAPICache.clear(namespace="markets")` after a successful vendor update, so the map reflects new trust scores immediately rather than waiting out the TTL.
- `backend/requirements.txt`: added `fastapi-cache2==0.2.2`.
- `backend/tests/test_cache.py` (new): unit tests against the real `fastapi_cache2` API — cache hit/miss, TTL expiry, `FastAPICache.clear()` invalidation, and confirming exceptions are never cached.

**Note for maintainer:** `backend/tests/test_cache.py` is a new file and is not yet included in `.github/workflows/ci.yml`'s test command (`pytest tests/test_ci.py`, which runs only that one file by name). I've verified it manually (`pytest tests/test_cache.py -v`, all passing) but wanted to flag this rather than modify `ci.yml` without discussion. Happy to add it to the CI command if preferred.

## Checklist

- [x] `npm run lint` passes with no errors *(no frontend changes in this PR)*
- [x] `npm run build` compiles without TypeScript errors *(no frontend changes in this PR)*
- [x] `python -m pytest` passes (including new tests I added) — verified `tests/test_ci.py` (9 passed) and `tests/test_cache.py` (4 passed)
- [x] No `.env` files, API keys, secrets, model weights, or `__pycache__` in this diff
- [x] Branch is rebased on `main`, not merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The markets map data endpoint now uses caching to improve response times.
  * Cache is automatically invalidated when vendor trust scores are recalculated to keep data fresh.

* **Tests**
  * Added tests covering cache TTL behavior, manual invalidation, and ensuring errors inside cached handlers aren’t stored.

* **Chores**
  * Added the required caching library dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->