### PR TITLE
fix: add navigation links to FAQPage (was orphaned with no route access)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 
 export default function Footer() {
   const { t } = useTranslation();
@@ -13,6 +14,9 @@ export default function Footer() {
 
         {/* Copyright — matches body paragraph (text-on-surface-variant) */}
         <p className="text-on-surface-variant text-sm leading-relaxed text-center sm:text-right m-0">
+          <Link to="/faq" className="font-[family-name:var(--font-mono)] text-xs tracking-widest text-on-surface-variant hover:text-neon transition-colors duration-200 no-underline mr-4">
+            {t('components.footer.faq')}
+          </Link>
           {t('components.footer.copyright')}
         </p>
 

--- a/src/i18n/locales/bn.json
+++ b/src/i18n/locales/bn.json
@@ -34,6 +34,7 @@
     "stepsTo": "নিশ্চিততার জন্য তিন ধাপ",
     "certainty": "নিশ্চিততা",
     "faqTitle": "প্রোটোকল FAQ",
+    "viewAllFaqs": "সব FAQ দেখুন",
     "frequentlyAsked": "প্রায়শই জিজ্ঞাসিত",
     "questions": "প্রশ্ন",
     "assessmentReady": "মূল্যায়ন প্রস্তুত",
@@ -317,6 +318,7 @@
     },
     "footer": {
       "freshscanAi": "FreshScan AI",
+      "faq": "FAQ",
       "copyright": "© 2026 FreshScan AI. সর্বাধিকার সংরক্ষিত। নির্ভুল বুদ্ধিমত্তা।"
     },
     "layout": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -34,6 +34,7 @@
     "stepsTo": "Three steps to",
     "certainty": "certainty",
     "faqTitle": "PROTOCOL FAQ",
+    "viewAllFaqs": "VIEW ALL FAQS",
     "frequentlyAsked": "Frequently Asked",
     "questions": "Questions",
     "assessmentReady": "ASSESSMENT READY",
@@ -323,6 +324,7 @@
     },
     "footer": {
       "freshscanAi": "FreshScan AI",
+      "faq": "FAQ",
       "copyright": "© 2026 FreshScan AI. All rights reserved. Precision Intelligence."
     },
     "layout": {

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -34,6 +34,7 @@
     "stepsTo": "निश्चितता के लिए तीन कदम",
     "certainty": "निश्चितता",
     "faqTitle": "प्रोटोकॉल सामान्य प्रश्न",
+    "viewAllFaqs": "सभी FAQ देखें",
     "frequentlyAsked": "अक्सर पूछे जाने वाले",
     "questions": "प्रश्न",
     "assessmentReady": "मूल्यांकन तैयार",
@@ -317,6 +318,7 @@
     },
     "footer": {
       "freshscanAi": "FreshScan AI",
+      "faq": "FAQ",
       "copyright": "© 2026 FreshScan AI. सर्वाधिकार सुरक्षित। सटीक बुद्धिमत्ता।"
     },
     "layout": {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -242,6 +242,17 @@ export default function LandingPage() {
               </div>
             ))}
           </div>
+
+          {/* Link to full FAQ page */}
+          <div className="mt-8 text-center">
+            <Link
+              to="/faq"
+              className="inline-flex items-center gap-2 font-[family-name:var(--font-mono)] text-xs tracking-widest text-neon border border-neon/40 px-5 py-2.5 hover:bg-neon hover:text-on-primary transition-all duration-200 no-underline"
+            >
+              {t('landing.viewAllFaqs')}
+              <span aria-hidden>→</span>
+            </Link>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
- Add 'VIEW ALL FAQS' button at bottom of LandingPage FAQ section
- Add FAQ link in Footer (all pages)
- Add i18n keys: landing.viewAllFaqs, components.footer.faq (en/hi/bn)

The /faq route existed but had zero navigation links pointing to it, making the dedicated FAQ page completely unreachable on production.

<!--
  Please ensure you have read CONTRIBUTING.md before opening a PR.
-->

## Description

<!-- Provide a clear description of what this PR does and why it is needed. Link to the relevant issue (e.g., Closes #123). If it includes UI changes, please include screenshots here. -->

## Checklist

- [ ] `npm run lint` passes with no errors
- [ ] `npm run build` compiles without TypeScript errors
- [ ] `python -m pytest` passes (including new tests I added)
- [ ] No `.env` files, API keys, secrets, model weights, or `__pycache__` in this diff
- [ ] Branch is rebased on `main`, not merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated FAQ link in the landing page’s FAQ section for quicker access to all questions.
  * Added an FAQ link in the footer for easier site navigation.
  * Expanded FAQ-related text for English, Hindi, and Bangla languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->